### PR TITLE
We need to offset the playback position for DVRLive sessions

### DIFF
--- a/yospace/src/integration/YospaceManager.ts
+++ b/yospace/src/integration/YospaceManager.ts
@@ -123,7 +123,16 @@ export class YospaceManager extends DefaultEventDispatcher<YospaceEventMap> {
     }
 
     private updateYospaceWithPlaybackPosition = () => {
-        const currentTime = this.player.currentTime * 1000;
+        let currentTime = this.player.currentTime * 1000;
+
+        // For Yospace DVRLive sessions we need to offset the playback position from the stream start time
+        if (this.yospaceTypedSource?.ssai.streamType === 'livepause') {
+            const ast = this.sessionManager?.getManifestData('availabilityStartTime');
+            const sst = new Date(this.sessionManager?.getStreamStart());
+            const delta = sst?.getTime() - ast?.getTime() || 0;
+            currentTime = Math.round(currentTime - delta);
+        }
+
         this.sessionManager?.onPlayheadUpdate(currentTime);
     };
 


### PR DESCRIPTION
The current behaviour of the THEOplayer Yospace web connector is to always report the player current time to the Yospace SDK regardless of the playback mode. But for Yospace DVRLive sessions (called `livepause` in the connector) the time should be offset from stream start.

See https://developer.yospace.com/sdk-documentation/javascript/userguide/latest/en/provide-necessary-information-to-the-sdk.html#video-playback-position for more information.

Examples of this logic is also available in the Yospace sample reference apps (see shaka/shaka-adapter.js).